### PR TITLE
Fix solana bash version command README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl --proto '=https' --tlsv1.2 -sSfL https://solana-install.solana.workers.dev 
 ```
 * Close and reopen your Terminal.
 ```
-solana version
+solana --version
 ```
 * If you get `solana: command not found` RUN :
 ```bash


### PR DESCRIPTION
Error occurred while using
```root@Orion:~# solana version
error: Found argument 'version' which wasn't expected, or isn't valid in this context

USAGE:
    solana [FLAGS] [OPTIONS] <SUBCOMMAND>

For more information try --help
root@Orion:~# solana --version
solana-cli 2.1.19 (src:c696ac8f; feat:1416569292, client:Agave)
```